### PR TITLE
fix: fix missing v prefix

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -43,7 +43,7 @@ download_release() {
 	version="$1"
 	filename="$2"
 
-	url="$GH_REPO/archive/refs/tags/${version}.tar.gz"
+	url="$GH_REPO/archive/refs/tags/v${version}.tar.gz"
 
 	echo "* Downloading $TOOL_NAME release $version..."
 	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"


### PR DESCRIPTION
Prior to this PR the following error is printed:


```
* Downloading staticcheck release 0.4.7...
curl: (22) The requested URL returned error: 404
asdf-staticcheck: Could not download https://github.com/dominikh/go-tools/archive/refs/tags/0.4.7.tar.gz
```

This PR fixes that by adding the `v` prefix when downloading assets from Github